### PR TITLE
Add modifiable configuration vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,17 @@ fail2ban_bantime: 10m
 fail2ban_findtime: 10m
 fail2ban_maxretry: 5
 fail2ban_destemail: root@localhost
-fail2ban_sender: root@{{ ansible_fqdn}}
+fail2ban_sender: root@{{ ansible_fqdn }}
+
+fail2ban_configuration: []
+#  - option: loglevel
+#    value: "INFO"
+#    section: Definition
+
+fail2ban_jail_configuration: []
+#  - option: ignoreself
+#    value: "true"
+#    section: DEFAULT
 ```
 
 Requirements

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,4 +10,14 @@ fail2ban_bantime: 10m
 fail2ban_findtime: 10m
 fail2ban_maxretry: 5
 fail2ban_destemail: root@localhost
-fail2ban_sender: root@{{ ansible_fqdn}}
+fail2ban_sender: root@{{ ansible_fqdn }}
+
+fail2ban_configuration: []
+#  - option: loglevel
+#    value: "INFO"
+#    section: Definition
+
+fail2ban_jail_configuration: []
+#  - option: ignoreself
+#    value: "true"
+#    section: DEFAULT

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
     option: "{{ item.option }}"
     value: "{{ item.value }}"
   with_items:
-    - "{{ fail2ban_configuration }}"
+    - "{{ fail2ban_base_configuration + fail2ban_configuration }}"
   notify:
     - restart fail2ban
   loop_control:
@@ -28,7 +28,7 @@
     option: "{{ item.option }}"
     value: "{{ item.value }}"
   with_items:
-    - "{{ fail2ban_jail_configuration }}"
+    - "{{ fail2ban_base_jail_configuration + fail2ban_jail_configuration }}"
   notify:
     - restart fail2ban
   loop_control:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,10 +34,16 @@
   loop_control:
     label: "{{ item.option }}"
 
-- name: touch /var/log/auth.log
+- name: stat auth log file
+  stat:
+    path: /var/log/auth.log
+  register: auth
+
+- name: touch auth log file
   file:
     path: /var/log/auth.log
     state: touch
+  when: auth.stat.exists is defined and not auth.stat.exists
 
 - name: start and enable fail2ban
   service:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -5,7 +5,7 @@ fail2ban_packages:
 
 fail2ban_service: fail2ban
 
-fail2ban_configuration:
+fail2ban_base_configuration:
   - option: loglevel
     value: "{{ fail2ban_loglevel }}"
     section: Definition
@@ -13,7 +13,7 @@ fail2ban_configuration:
     value: "{{ fail2ban_logtarget }}"
     section: Definition
 
-fail2ban_jail_configuration:
+fail2ban_base_jail_configuration:
   - option: ignoreself
     value: "{{ fail2ban_ignoreself }}"
     section: DEFAULT


### PR DESCRIPTION
---
name: Add modifiable configuration vars
about: Be able to customize the Fail2ban configurations
---

**Describe the change**
Before, it was impossible to customize the configurations without having to override `fail2ban_configuration` and `fail2ban_jail_configuration` present in `vars.yml`, which isn't ideal.

Now, this variables are in `default.yml`, which are concatenated to `fail2ban_base_configuration` and `fail2ban_base_jail_configuration`.
**Testing**
We have deployed this branch in our bastion.
