### PR TITLE
Fix invalid int literal

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,8 +6,11 @@ fail2ban_logtarget: /var/log/fail2ban.log
 
 fail2ban_ignoreself: "true"
 fail2ban_ignoreips: "127.0.0.1/8 ::1"
-fail2ban_bantime: 10m
-fail2ban_findtime: 10m
+
+# In seconds
+fail2ban_bantime: 600
+fail2ban_findtime: 600
+
 fail2ban_maxretry: 5
 fail2ban_destemail: root@localhost
 fail2ban_sender: root@{{ ansible_fqdn }}


### PR DESCRIPTION
---
name: Pull request
about: Fix errors about invalid int literals.

---

**Describe the change**
Using `10m` is invalid and produces: `ERROR  NOK: ("invalid literal for int() with base 10: 'None'",)`

**Testing**
No more errors after restarting the server.
Fail2ban version: 0.9.6
