### PR TITLE
Fix assert test fail2ban_configuration and fail2ban_jail_configuration

### DIFF
--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -74,6 +74,7 @@
       - item.value | length > 0
       - item.section is defined
       - item.section | length > 0
+  loop: "{{ fail2ban_configuration }}"
   when:
     - fail2ban_configuration is defined
     - fail2ban_configuration | length > 0
@@ -88,6 +89,7 @@
       - item.value | length > 0
       - item.section is defined
       - item.section | length > 0
+  loop: "{{ fail2ban_jail_configuration }}"
   when:
     - fail2ban_jail_configuration is defined
     - fail2ban_jail_configuration | length > 0


### PR DESCRIPTION

Adding extra config isn't possible because the assert fails with:

TASK [robertdebock.fail2ban : test if fail2ban_jail_configuration is set correctly] ***
fatal: [gepdata-dev]: FAILED! => {
    "assertion": "item.option is defined",
    "changed": false,
    "evaluated_to": false,
    "msg": "Assertion failed"
}

Adding the loop fixes it as we now test the elements of the passed list
