### PR TITLE
Feat: allow a permanent ban

### DIFF
--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -35,7 +35,7 @@
     that:
       - fail2ban_bantime is defined
       - fail2ban_bantime is number
-      - fail2ban_bantime > 0
+      - fail2ban_bantime >= -1 and fail2ban_bantime !=0
     quiet: yes
 
 - name: test if fail2ban_findtime is set correctly

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,8 +2,9 @@
 # tasks file for fail2ban
 
 - name: include assert.yml
-  include_tasks: assert.yml
+  import_tasks: assert.yml
   run_once: yes
+  delegate_to: localhost
 
 - name: install fail2ban
   package:


### PR DESCRIPTION
---
name: Allow a permanent ban
about: According to the fail2ban documentation it is possible to make a permanent ban by setting a negative value to "bantime".
See [Jail_Options](https://www.fail2ban.org/wiki/index.php/MANUAL_0_8#Jail_Options)

---

**Describe the change**
First of all I simply changed the assertion test to allow the value -1 and only -1 in order to guarantee a permanent ban.
```yaml
- fail2ban_bantime >= -1 and fail2ban_bantime !=0
```
In a second step I noticed a bad use of the [run_once](https://docs.ansible.com/ansible/latest/user_guide/playbooks_strategies.html#running-on-a-single-machine-with-run-once).
If a test fails, it is only executed for the first machine. This means that only the first machine can be taken out of the execution pool, whereas the assert file should stop the execution of the role (this is my point of view).
So I modify it to perfom assert on local machine, but delegate_to imposes an import instead of an include. 
Based on the code in the tasks/main.yml file I don't think an include is necessary. [import vs include](https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse.html#id6)
```yaml
- name: include assert.yml
  import_tasks: assert.yml
  run_once: yes
  delegate_to: localhost
```

**Testing**
Simply have two managed nodes and configure fail2ban_bantime = -1 :-)

```yaml
- name:                              Configuration for ansible lab
  hosts:                              node1:node2
  become:                             true
  tasks:
    - name:                           Upgrade all packages
      dnf:
        name:                         "*"
        state:                        latest
    - name:                           Ensure fail2ban is installed
      import_role:
        name:                         robertdebock.fail2ban
      vars:
        fail2ban_bantime:             -1
```