### PR TITLE
Change /etc/fail2ban/fail2ban.conf to /etc/fail2ban/fail2ban.local

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,9 +11,9 @@
     name: "{{ fail2ban_packages }}"
     state: present
 
-- name: configure fail2ban.conf
+- name: configure fail2ban.local
   community.general.ini_file:
-    path: /etc/fail2ban/fail2ban.conf
+    path: /etc/fail2ban/fail2ban.local
     section: "{{ item.section }}"
     option: "{{ item.option }}"
     value: "{{ item.value }}"


### PR DESCRIPTION
The config file path for the `configure fail2ban.conf` task should use the `.local` extension, like the `configure jail.local` task uses.

> Every .conf file can be overridden with a file named .local. The .conf file is read first, then .local, with later settings overriding earlier ones. Thus, a .local file doesn't have to include everything in the corresponding .conf file, only those settings that you wish to override.
> 
> Modifications should take place in the .local and not in the .conf. This avoids merging problem when upgrading. These files are well documented and detailed information should be available there. 

Source: https://www.fail2ban.org/wiki/index.php/MANUAL_0_8