### PR TITLE
`ignoreip` belongs in jail.local, not fail2ban.local

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -13,13 +13,13 @@ fail2ban_base_configuration:
   - option: logtarget
     value: "{{ fail2ban_logtarget }}"
     section: Definition
-  - option: ignoreip
-    value: "{{ fail2ban_ignoreips | join(' ') }}"
-    section: DEFAULT
 
 fail2ban_base_jail_configuration:
   - option: ignoreself
     value: "{{ fail2ban_ignoreself }}"
+    section: DEFAULT
+  - option: ignoreip
+    value: "{{ fail2ban_ignoreips | join(' ') }}"
     section: DEFAULT
   - option: bantime
     value: "{{ fail2ban_bantime }}"


### PR DESCRIPTION
---
name: Pull request
about: move ignoreip to jail.local. Fixes #15 
---

**Describe the change**
Moved `ignoreip` to `fail2ban_base_jail_configuration`

**Testing**
Deployed using this fork on a Debian system. `fail2ban-client get sshd ignoreip` now returns the list of ignored ip addresses.
