### PR TITLE
Allow to configure actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ fail2ban_jail_configuration: []
 #    value: "true"
 #    section: DEFAULT
 
+fail2ban_action_configurations: []
+#  - action: iptables
+#    section: Init
+#    option: blocktype
+#    value: DROP
+
 # Path to directory containing filters to copy in filter.d
 # fail2ban_filterd_path:
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,5 +26,11 @@ fail2ban_jail_configuration: []
 #    value: "true"
 #    section: DEFAULT
 
+fail2ban_action_configurations: []
+#  - action: iptables
+#    section: Init
+#    option: blocktype
+#    value: DROP
+
 # Path to directory containing filters to copy in filter.d
 # fail2ban_filterd_path:

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -113,6 +113,26 @@
   when:
     - fail2ban_jail_configuration is defined
 
+- name: assert | Test fail2ban_action_configurations
+  ansible.builtin.assert:
+    that:
+      - item.option is defined
+      - item.option is string
+      - item.option is not none
+      - item.value is defined
+      - item.section is defined
+      - item.section is string
+      - item.section is not none
+      - item.action is defined
+      - item.action is string
+      - item.action is not none
+    quiet: true
+  loop: "{{ fail2ban_action_configurations }}"
+  loop_control:
+    label: "{{ item.action }} {{ item.option }}"
+  when:
+    - fail2ban_action_configurations is defined
+
 - name: assert | Test item in fail2ban_filterd_path
   ansible.builtin.assert:
     that:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,6 +50,19 @@
   loop_control:
     label: "{{ item.option }}"
 
+- name: Configure actions
+  community.general.ini_file:
+    path: "/etc/fail2ban/action.d/{{ item.action }}.local"
+    section: "{{ item.section }}"
+    option: "{{ item.option }}"
+    value: "{{ item.value }}"
+    mode: "0640"
+  loop: "{{ fail2ban_action_configurations }}"
+  notify:
+    - Restart fail2ban
+  loop_control:
+    label: "{{ item.action }} {{ item.option }}"
+
 - name: Stat auth log file
   ansible.builtin.stat:
     path: /var/log/auth.log


### PR DESCRIPTION
---
name: Allow to configure actions
about: This adds support to configure actions

---

**Describe the change**
With this we are able to also configure actions by creating proper `*.local` files under `/etc/fail2ban/action.d/`.

**Testing**
Goal is to set the blocktype for the iptables action to a silent DROP - therefore we use the following inventory variable:

```yaml
fail2ban_action_configurations:
  - action: iptables
    section: Init
    option: blocktype
    value: DROP
  - action: iptables
    section: Init?family=inet6
    option: blocktype
    value: DROP
```

which results in 
```
# cat /etc/fail2ban/action.d/iptables.local

[Init]
blocktype = DROP
[Init?family=inet6]
blocktype = DROP
```

```
#  iptables -L -nv
Chain INPUT (policy ACCEPT 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination
  210 19478 f2b-apache  6    --  *      *       0.0.0.0/0            0.0.0.0/0            multiport dports 80,443

Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination

Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination

Chain f2b-apache (1 references)
 pkts bytes target     prot opt in     out     source               destination
    5   260 DROP       0    --  *      *       10.xx.yyy.zz         0.0.0.0/0
  200 18958 RETURN     0    --  *      *       0.0.0.0/0            0.0.0.0/0
```