### PR TITLE
Update ansible_fqdn to ansible_facts.fqdn

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ fail2ban_findtime: 600
 
 fail2ban_maxretry: 5
 fail2ban_destemail: root@localhost
-fail2ban_sender: root@{{ ansible_fqdn }}
+fail2ban_sender: root@{{ ansible_facts.fqdn }}
 
 fail2ban_configuration: []
 #  - option: loglevel

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,7 @@ fail2ban_findtime: 600
 
 fail2ban_maxretry: 5
 fail2ban_destemail: root@localhost
-fail2ban_sender: root@{{ ansible_fqdn }}
+fail2ban_sender: root@{{ ansible_facts.fqdn }}
 
 fail2ban_configuration: []
 #  - option: loglevel


### PR DESCRIPTION
Updates ansible_fqdn to ansible_facts.fqdn to fix the issue where ansible_fqdn is undefined in fail2ban_sender assertion.

Testing: Verified this fixes the issue by overriding the fail2ban_sender variable in a fail2ban playbook to be ansible_facts.fqdn. 